### PR TITLE
feat: urls for bets

### DIFF
--- a/src/components/Bet.js
+++ b/src/components/Bet.js
@@ -9,8 +9,8 @@ export default function Bet({
 }) {
   return (
     <div className={`flex shadow-sm rounded-md ${className}`}>
-      <div className="flex-1 flex items-center justify-between border border-gray-200 bg-white rounded-r-md truncate">
-        <div className="flex-1 px-4 py-2 text-sm leading-5 truncate">
+      <div className="flex-1 flex items-center justify-between border border-gray-200 bg-white rounded-r-md">
+        <div className="flex-1 px-4 py-2 text-sm leading-5">
           <a href={issue.url} target="_blank" className="text-gray-900 font-medium hover:text-gray-600 transition ease-in-out duration-150" title={issue.title} rel="noreferrer">{issue.title}</a>
           <p className="text-gray-500">{issue.appetite}</p>
         </div>

--- a/src/components/CycleSidebar.js
+++ b/src/components/CycleSidebar.js
@@ -20,35 +20,13 @@ export default function CycleSidebar({
 
       <div>
         {
-          availableBets.map((bet, index) => (
-            <Bet key={index} issue={bet} toggled={visibleBet && bet.url === visibleBet.url} disabled={availableBets.length === 1} className="mt-3" onChange={onBetChange} />
-          ))
+          availableBets.map((bet, index) => {
+            return <Bet key={index} issue={bet} toggled={visibleBet && bet.url === visibleBet.url}  className="mt-3" onChange={onBetChange} />
+          })
         }
         {
           !visibleBet && (
             <p className="italic text-sm text-gray-400 mt-4">No bets have been created yet.</p>
-          )
-        }
-      </div>
-
-      <div className="mt-8 pb-5 border-b border-gray-200 space-y-2">
-        <h3 className="text-lg leading-6 font-medium text-gray-900">
-          Scopes
-        </h3>
-        <p className="max-w-4xl text-sm leading-5 text-gray-500">
-          Subtasks to make the development of the bet easier.
-        </p>
-      </div>
-
-      <div>
-        {
-          (visibleScopes || []).map((scope, index) => (
-            <Scope key={index} issue={scope} toggled={!!selectedScopes.find(s => s.url === scope.url)} onChange={onScopeChange} className="mt-3" />
-          ))
-        }
-        {
-          !(visibleScopes || []).length && (
-            <p className="italic text-sm text-gray-400 mt-4">No scopes have been created yet.</p>
           )
         }
       </div>


### PR DESCRIPTION
### Description

- Bets are now available trough URLs (query string `?issue=<BET_ISSUE_NUMBER>` - `e.g. http://localhost:3000/projects/org/asyncapi/16/cycles/e4232524?issue=663`
- Minimalist UI for Bets
- Removed Scopes

To prevent conflicts I've used `add-connect-functionality` branch / #21 

Fixes #13